### PR TITLE
Updating link to Vendr product issue tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you require any help with setup or you are having problems getting it working
 
 ## Raising an Issue
 
-If you find any issues with the demo store itself please raise them in the [issues section of this repository](https://github.com/vendrhub/vendr-demo-store/issues), if the issue is a core Vendr product issue however, please raise these in the [issue tracker on the Vendr repository](https://github.com/vendrhub/vendr-demo-store/issues)
+If you find any issues with the demo store itself please raise them in the [issues section of this repository](https://github.com/vendrhub/vendr-demo-store/issues), if the issue is a core Vendr product issue however, please raise these in the [issue tracker on the Vendr repository](https://github.com/vendrhub/vendr/issues)
 
 ## (Probable) FAQs
 


### PR DESCRIPTION
So excited to see a Vendr demo finally out in the wild! 🤘

I noticed the link to the Vendr product issue tracker was wrong in the README, so here's a fix...