### PR TITLE
Use OrderAddressDto for billing and shipping

### DIFF
--- a/src/Vendr.DemoStore.Web/Views/CheckoutInformationPage.cshtml
+++ b/src/Vendr.DemoStore.Web/Views/CheckoutInformationPage.cshtml
@@ -26,28 +26,30 @@
     <h3 class="text-xl font-medium mb-4 mt-8">Billing Address</h3>
 
     <div class="flex -mx-1">
-        <input name="billingFirstname" type="text" placeholder="First name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
+        <input name="billing.Firstname" type="text" placeholder="First name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
                value="@(Model.Order.CustomerInfo.FirstName)" required />
-        <input name="billingLastname" type="text" placeholder="Last name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
+        <input name="billing.Lastname" type="text" placeholder="Last name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
                value="@(Model.Order.CustomerInfo.LastName)" required />
     </div>
-    <input name="billingAddressLine1" type="text" placeholder="Address (line 1)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+
+    <input name="billing.AddressLine1" type="text" placeholder="Address (line 1)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
            value="@(Model.Order.Properties["billingAddressLine1"])" required />
-    <input name="billingAddressLine2" type="text" placeholder="Address (line 2)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+    <input name="billing.AddressLine2" type="text" placeholder="Address (line 2)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
            value="@(Model.Order.Properties["billingAddressLine2"])" />
-    <input name="billingCity" type="text" placeholder="City" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+    <input name="billing.City" type="text" placeholder="City" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
            value="@(Model.Order.Properties["billingCity"])" required />
+
     <div class="flex -mx-1">
-        <select name="billingCountry" placeholder="Country" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full">
+        <select name="billing.Country" placeholder="Country" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full">
             @foreach (var country in Model.Countries)
             {
                 <option value="@(country.Id)" @Html.Raw(Model.Order.PaymentInfo.CountryId == country.Id ? "selected=\"selected\"" : "")>@(country.Name)</option>
             }
         </select>
-        <input name="billingZipCode" type="text" placeholder="Postcode" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
+        <input name="billing.ZipCode" type="text" placeholder="Postcode" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
                value="@(Model.Order.Properties["billingZipCode"])" required />
     </div>
-    <input name="billingTelephone" type="text" placeholder="Phone" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+    <input name="billing.Telephone" type="text" placeholder="Phone" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
            value="@(Model.Order.Properties["billingTelephone"])" />
 
     <label class="flex items-center mb-2 cursor-pointer">
@@ -59,28 +61,30 @@
         <h3 class="text-xl font-medium mb-4 mt-8">Shipping Address</h3>
 
         <div class="flex -mx-1">
-            <input name="shippingFirstname" type="text" placeholder="First name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
+            <input name="shipping.Firstname" type="text" placeholder="First name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
                    value="@(Model.Order.Properties["shippingFirstName"])" />
-            <input name="shippingLastname" type="text" placeholder="Last name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
+            <input name="shipping.Lastname" type="text" placeholder="Last name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
                    value="@(Model.Order.Properties["shippingLastName"])" />
         </div>
-        <input name="shippingAddressLine1" type="text" placeholder="Address (line 1)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+
+        <input name="shipping.AddressLine1" type="text" placeholder="Address (line 1)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
                value="@(Model.Order.Properties["shippingAddressLine1"])" />
-        <input name="shippingAddressLine2" type="text" placeholder="Address (line 2)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+        <input name="shipping.AddressLine2" type="text" placeholder="Address (line 2)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
                value="@(Model.Order.Properties["shippingAddressLine2"])" />
-        <input name="shippingCity" type="text" placeholder="City" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+        <input name="shipping.City" type="text" placeholder="City" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
                value="@(Model.Order.Properties["shippingCity"])" />
+
         <div class="flex -mx-1">
-            <select name="shippingCountry" placeholder="Country" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full">
+            <select name="shipping.Country" placeholder="Country" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full">
                 @foreach (var country in Model.Countries)
                 {
                     <option value="@(country.Id)" @Html.Raw(Model.Order.PaymentInfo.CountryId == country.Id ? "selected=\"selected\"" : "")>@(country.Name)</option>
                 }
             </select>
-            <input name="shippingZipCode" type="text" placeholder="Postcode" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
+            <input name="shipping.ZipCode" type="text" placeholder="Postcode" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
                    value="@(Model.Order.Properties["shippingZipCode"])" />
         </div>
-        <input name="shippingTelephone" type="text" placeholder="Phone" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+        <input name="shipping.Telephone" type="text" placeholder="Phone" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
                value="@(Model.Order.Properties["shippingTelephone"])" />
 
     </div>

--- a/src/Vendr.DemoStore.Web/Views/CheckoutInformationPage.cshtml
+++ b/src/Vendr.DemoStore.Web/Views/CheckoutInformationPage.cshtml
@@ -26,30 +26,30 @@
     <h3 class="text-xl font-medium mb-4 mt-8">Billing Address</h3>
 
     <div class="flex -mx-1">
-        <input name="billing.Firstname" type="text" placeholder="First name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
+        <input name="billingAddress.Firstname" type="text" placeholder="First name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
                value="@(Model.Order.CustomerInfo.FirstName)" required />
-        <input name="billing.Lastname" type="text" placeholder="Last name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
+        <input name="billingAddress.Lastname" type="text" placeholder="Last name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
                value="@(Model.Order.CustomerInfo.LastName)" required />
     </div>
 
-    <input name="billing.AddressLine1" type="text" placeholder="Address (line 1)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+    <input name="billingAddress.Line1" type="text" placeholder="Address (line 1)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
            value="@(Model.Order.Properties["billingAddressLine1"])" required />
-    <input name="billing.AddressLine2" type="text" placeholder="Address (line 2)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+    <input name="billingAddress.Line2" type="text" placeholder="Address (line 2)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
            value="@(Model.Order.Properties["billingAddressLine2"])" />
-    <input name="billing.City" type="text" placeholder="City" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+    <input name="billingAddress.City" type="text" placeholder="City" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
            value="@(Model.Order.Properties["billingCity"])" required />
 
     <div class="flex -mx-1">
-        <select name="billing.Country" placeholder="Country" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full">
+        <select name="billingAddress.Country" placeholder="Country" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full">
             @foreach (var country in Model.Countries)
             {
                 <option value="@(country.Id)" @Html.Raw(Model.Order.PaymentInfo.CountryId == country.Id ? "selected=\"selected\"" : "")>@(country.Name)</option>
             }
         </select>
-        <input name="billing.ZipCode" type="text" placeholder="Postcode" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
+        <input name="billingAddress.ZipCode" type="text" placeholder="Postcode" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
                value="@(Model.Order.Properties["billingZipCode"])" required />
     </div>
-    <input name="billing.Telephone" type="text" placeholder="Phone" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+    <input name="billingAddress.Telephone" type="text" placeholder="Phone" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
            value="@(Model.Order.Properties["billingTelephone"])" />
 
     <label class="flex items-center mb-2 cursor-pointer">
@@ -61,30 +61,30 @@
         <h3 class="text-xl font-medium mb-4 mt-8">Shipping Address</h3>
 
         <div class="flex -mx-1">
-            <input name="shipping.Firstname" type="text" placeholder="First name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
+            <input name="shippingAddress.Firstname" type="text" placeholder="First name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
                    value="@(Model.Order.Properties["shippingFirstName"])" />
-            <input name="shipping.Lastname" type="text" placeholder="Last name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
+            <input name="shippingAddress.Lastname" type="text" placeholder="Last name" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
                    value="@(Model.Order.Properties["shippingLastName"])" />
         </div>
 
-        <input name="shipping.AddressLine1" type="text" placeholder="Address (line 1)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+        <input name="shippingAddress.Line1" type="text" placeholder="Address (line 1)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
                value="@(Model.Order.Properties["shippingAddressLine1"])" />
-        <input name="shipping.AddressLine2" type="text" placeholder="Address (line 2)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+        <input name="shippingAddress.Line2" type="text" placeholder="Address (line 2)" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
                value="@(Model.Order.Properties["shippingAddressLine2"])" />
-        <input name="shipping.City" type="text" placeholder="City" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+        <input name="shippingAddress.City" type="text" placeholder="City" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
                value="@(Model.Order.Properties["shippingCity"])" />
 
         <div class="flex -mx-1">
-            <select name="shipping.Country" placeholder="Country" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full">
+            <select name="shippingAddress.Country" placeholder="Country" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full">
                 @foreach (var country in Model.Countries)
                 {
                     <option value="@(country.Id)" @Html.Raw(Model.Order.PaymentInfo.CountryId == country.Id ? "selected=\"selected\"" : "")>@(country.Name)</option>
                 }
             </select>
-            <input name="shipping.ZipCode" type="text" placeholder="Postcode" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
+            <input name="shippingAddress.ZipCode" type="text" placeholder="Postcode" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 mx-1 w-full"
                    value="@(Model.Order.Properties["shippingZipCode"])" />
         </div>
-        <input name="shipping.Telephone" type="text" placeholder="Phone" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
+        <input name="shippingAddress.Telephone" type="text" placeholder="Phone" class="block placeholder-gray-700 border border-gray-300 rounded py-2 px-4 mb-2 w-full"
                value="@(Model.Order.Properties["shippingTelephone"])" />
 
     </div>

--- a/src/Vendr.DemoStore/Vendr.DemoStore.csproj
+++ b/src/Vendr.DemoStore/Vendr.DemoStore.csproj
@@ -383,6 +383,7 @@
       <DependentUpon>Generated.cs</DependentUpon>
     </Compile>
     <Compile Include="Web\Controllers\SearchSurfaceController.cs" />
+    <Compile Include="Web\Dtos\OrderAddressDto.cs" />
     <Compile Include="Web\Extensions\UriExtensions.cs" />
     <Compile Include="Web\Extractors\CompositeNameUmbracoProductSnapshotDecorator.cs" />
     <Compile Include="Web\Extractors\CompositeNameUmbracoProductInformationExtractor.cs" />

--- a/src/Vendr.DemoStore/Web/Controllers/CheckoutSurfaceController.cs
+++ b/src/Vendr.DemoStore/Web/Controllers/CheckoutSurfaceController.cs
@@ -45,27 +45,27 @@ namespace Vendr.DemoStore.Web.Controllers
                             { Constants.Properties.Customer.EmailPropertyAlias, model.Email },
                             { "marketingOptIn", model.MarketingOptIn ? "1" : "0" },
 
-                            { Constants.Properties.Customer.FirstNamePropertyAlias, model.Billing.FirstName },
-                            { Constants.Properties.Customer.LastNamePropertyAlias, model.Billing.LastName },
-                            { "billingAddressLine1", model.Billing.AddressLine1 },
-                            { "billingAddressLine2", model.Billing.AddressLine2 },
-                            { "billingCity", model.Billing.City },
-                            { "billingZipCode", model.Billing.ZipCode },
-                            { "billingTelephone", model.Billing.Telephone },
+                            { Constants.Properties.Customer.FirstNamePropertyAlias, model.BillingAddress.FirstName },
+                            { Constants.Properties.Customer.LastNamePropertyAlias, model.BillingAddress.LastName },
+                            { "billingAddressLine1", model.BillingAddress.Line1 },
+                            { "billingAddressLine2", model.BillingAddress.Line2 },
+                            { "billingCity", model.BillingAddress.City },
+                            { "billingZipCode", model.BillingAddress.ZipCode },
+                            { "billingTelephone", model.BillingAddress.Telephone },
 
                             { "shippingSameAsBilling", model.ShippingSameAsBilling ? "1" : "0" },
-                            { "shippingFirstName", model.ShippingSameAsBilling ? model.Billing.FirstName : model.Shipping.FirstName },
-                            { "shippingLastName", model.ShippingSameAsBilling ? model.Billing.LastName : model.Shipping.LastName },
-                            { "shippingAddressLine1", model.ShippingSameAsBilling ? model.Billing.AddressLine1 : model.Shipping.AddressLine1 },
-                            { "shippingAddressLine2", model.ShippingSameAsBilling ? model.Billing.AddressLine2 : model.Shipping.AddressLine2 },
-                            { "shippingCity", model.ShippingSameAsBilling ? model.Billing.City : model.Shipping.City },
-                            { "shippingZipCode", model.ShippingSameAsBilling ? model.Billing.ZipCode : model.Shipping.ZipCode },
-                            { "shippingTelephone", model.ShippingSameAsBilling ? model.Billing.Telephone : model.Shipping.Telephone },
+                            { "shippingFirstName", model.ShippingSameAsBilling ? model.BillingAddress.FirstName : model.ShippingAddress.FirstName },
+                            { "shippingLastName", model.ShippingSameAsBilling ? model.BillingAddress.LastName : model.ShippingAddress.LastName },
+                            { "shippingAddressLine1", model.ShippingSameAsBilling ? model.BillingAddress.Line1 : model.ShippingAddress.Line1 },
+                            { "shippingAddressLine2", model.ShippingSameAsBilling ? model.BillingAddress.Line2 : model.ShippingAddress.Line2 },
+                            { "shippingCity", model.ShippingSameAsBilling ? model.BillingAddress.City : model.ShippingAddress.City },
+                            { "shippingZipCode", model.ShippingSameAsBilling ? model.BillingAddress.ZipCode : model.ShippingAddress.ZipCode },
+                            { "shippingTelephone", model.ShippingSameAsBilling ? model.BillingAddress.Telephone : model.ShippingAddress.Telephone },
 
                             { "comments", model.Comments }
                         })
-                        .SetPaymentCountryRegion(model.Billing.Country, null)
-                        .SetShippingCountryRegion(model.ShippingSameAsBilling ? model.Billing.Country : model.Shipping.Country, null);
+                        .SetPaymentCountryRegion(model.BillingAddress.Country, null)
+                        .SetShippingCountryRegion(model.ShippingSameAsBilling ? model.BillingAddress.Country : model.ShippingAddress.Country, null);
 
                     _orderService.SaveOrder(order);
 

--- a/src/Vendr.DemoStore/Web/Controllers/CheckoutSurfaceController.cs
+++ b/src/Vendr.DemoStore/Web/Controllers/CheckoutSurfaceController.cs
@@ -45,27 +45,27 @@ namespace Vendr.DemoStore.Web.Controllers
                             { Constants.Properties.Customer.EmailPropertyAlias, model.Email },
                             { "marketingOptIn", model.MarketingOptIn ? "1" : "0" },
 
-                            { Constants.Properties.Customer.FirstNamePropertyAlias, model.BillingFirstName },
-                            { Constants.Properties.Customer.LastNamePropertyAlias, model.BillingLastName },
-                            { "billingAddressLine1", model.BillingAddressLine1 },
-                            { "billingAddressLine2", model.BillingAddressLine2 },
-                            { "billingCity", model.BillingCity },
-                            { "billingZipCode", model.BillingZipCode },
-                            { "billingTelephone", model.BillingTelephone },
+                            { Constants.Properties.Customer.FirstNamePropertyAlias, model.Billing.FirstName },
+                            { Constants.Properties.Customer.LastNamePropertyAlias, model.Billing.LastName },
+                            { "billingAddressLine1", model.Billing.AddressLine1 },
+                            { "billingAddressLine2", model.Billing.AddressLine2 },
+                            { "billingCity", model.Billing.City },
+                            { "billingZipCode", model.Billing.ZipCode },
+                            { "billingTelephone", model.Billing.Telephone },
 
                             { "shippingSameAsBilling", model.ShippingSameAsBilling ? "1" : "0" },
-                            { "shippingFirstName", model.ShippingSameAsBilling ? model.BillingFirstName : model.ShippingFirstName },
-                            { "shippingLastName", model.ShippingSameAsBilling ? model.BillingLastName : model.ShippingLastName },
-                            { "shippingAddressLine1", model.ShippingSameAsBilling ? model.BillingAddressLine1 : model.ShippingAddressLine1 },
-                            { "shippingAddressLine2", model.ShippingSameAsBilling ? model.BillingAddressLine2 : model.ShippingAddressLine2 },
-                            { "shippingCity", model.ShippingSameAsBilling ? model.BillingCity : model.ShippingCity },
-                            { "shippingZipCode", model.ShippingSameAsBilling ? model.BillingZipCode : model.ShippingZipCode },
-                            { "shippingTelephone", model.ShippingSameAsBilling ? model.BillingTelephone : model.ShippingTelephone },
+                            { "shippingFirstName", model.ShippingSameAsBilling ? model.Billing.FirstName : model.Shipping.FirstName },
+                            { "shippingLastName", model.ShippingSameAsBilling ? model.Billing.LastName : model.Shipping.LastName },
+                            { "shippingAddressLine1", model.ShippingSameAsBilling ? model.Billing.AddressLine1 : model.Shipping.AddressLine1 },
+                            { "shippingAddressLine2", model.ShippingSameAsBilling ? model.Billing.AddressLine2 : model.Shipping.AddressLine2 },
+                            { "shippingCity", model.ShippingSameAsBilling ? model.Billing.City : model.Shipping.City },
+                            { "shippingZipCode", model.ShippingSameAsBilling ? model.Billing.ZipCode : model.Shipping.ZipCode },
+                            { "shippingTelephone", model.ShippingSameAsBilling ? model.Billing.Telephone : model.Shipping.Telephone },
 
                             { "comments", model.Comments }
                         })
-                        .SetPaymentCountryRegion(model.BillingCountry, null)
-                        .SetShippingCountryRegion(model.ShippingSameAsBilling ? model.BillingCountry : model.ShippingCountry, null);
+                        .SetPaymentCountryRegion(model.Billing.Country, null)
+                        .SetShippingCountryRegion(model.ShippingSameAsBilling ? model.Billing.Country : model.Shipping.Country, null);
 
                     _orderService.SaveOrder(order);
 

--- a/src/Vendr.DemoStore/Web/Dtos/OrderAddressDto.cs
+++ b/src/Vendr.DemoStore/Web/Dtos/OrderAddressDto.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Vendr.DemoStore.Web.Dtos
+{
+    public class OrderAddressDto
+    {
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+
+        public string AddressLine1 { get; set; }
+
+        public string AddressLine2 { get; set; }
+
+        public string ZipCode { get; set; }
+
+        public string City { get; set; }
+
+        public Guid Country { get; set; }
+
+        public string Telephone { get; set; }
+    }
+}

--- a/src/Vendr.DemoStore/Web/Dtos/OrderAddressDto.cs
+++ b/src/Vendr.DemoStore/Web/Dtos/OrderAddressDto.cs
@@ -8,9 +8,9 @@ namespace Vendr.DemoStore.Web.Dtos
 
         public string LastName { get; set; }
 
-        public string AddressLine1 { get; set; }
+        public string Line1 { get; set; }
 
-        public string AddressLine2 { get; set; }
+        public string Line2 { get; set; }
 
         public string ZipCode { get; set; }
 

--- a/src/Vendr.DemoStore/Web/Dtos/UpdateOrderInformationDto.cs
+++ b/src/Vendr.DemoStore/Web/Dtos/UpdateOrderInformationDto.cs
@@ -8,9 +8,9 @@ namespace Vendr.DemoStore.Web.Dtos
 
         public bool MarketingOptIn { get; set; }
 
-        public OrderAddressDto Billing { get; set; }
+        public OrderAddressDto BillingAddress { get; set; }
 
-        public OrderAddressDto Shipping { get; set; }
+        public OrderAddressDto ShippingAddress { get; set; }
 
         public bool ShippingSameAsBilling { get; set; }
 

--- a/src/Vendr.DemoStore/Web/Dtos/UpdateOrderInformationDto.cs
+++ b/src/Vendr.DemoStore/Web/Dtos/UpdateOrderInformationDto.cs
@@ -8,39 +8,11 @@ namespace Vendr.DemoStore.Web.Dtos
 
         public bool MarketingOptIn { get; set; }
 
-        public string BillingFirstName { get; set; }
+        public OrderAddressDto Billing { get; set; }
 
-        public string BillingLastName { get; set; }
-
-        public string BillingAddressLine1 { get; set; }
-
-        public string BillingAddressLine2 { get; set; }
-
-        public string BillingCity { get; set; }
-
-        public Guid BillingCountry { get; set; }
-
-        public string BillingZipCode { get; set; }
-
-        public string BillingTelephone { get; set; }
+        public OrderAddressDto Shipping { get; set; }
 
         public bool ShippingSameAsBilling { get; set; }
-
-        public string ShippingFirstName { get; set; }
-
-        public string ShippingLastName { get; set; }
-
-        public string ShippingAddressLine1 { get; set; }
-
-        public string ShippingAddressLine2 { get; set; }
-
-        public string ShippingCity { get; set; }
-
-        public Guid ShippingCountry { get; set; }
-
-        public string ShippingZipCode { get; set; }
-
-        public string ShippingTelephone { get; set; }
 
         public string Comments { get; set; }
 


### PR DESCRIPTION
I have added a `OrderAddressDto` to use same properties and ensure types of these are identical.
It can also be considered to move the `Email` property to `OrderAddressDto`. At the moment the email update the `Constants.Properties.Customer.EmailPropertyAlias`. I guess this is a "email" property on the customer and not specific on the billing and shipping addresses. Not sure how it was solved in Tea Commerce (maybe a custom via a custom order property), but often we need to specific a different email address and telefonenumber for shipping address to be able to send notification from shipping carrier to this person via email and SMS. Would it make sense to add email address property on both billing and shipping in Vendr since we already have this for telefonenumber?

Maybe it would also be useful to move this form to a partial view to be able to use `OrderAddressDto` model and e.g. `@Html.TextBoxFor(x => x.Billing.FirstName)` etc.

`AddressLine1` and `AddressLine2` could maybe be simplified to `Line1` and Line2` now since the object is an order address.