### PR TITLE
Add gift card variants

### DIFF
--- a/src/Vendr.DemoStore.Web/Views/Master.cshtml
+++ b/src/Vendr.DemoStore.Web/Views/Master.cshtml
@@ -10,7 +10,7 @@
         <title>@Model.MetaTitle</title>
         <meta name="description" content="@Model.MetaDescription" />
         <meta name="keywords" content="@Model.MetaKeywords" />
-        <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/1.1.4/tailwind.min.css" rel="stylesheet">
+        <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/1.4.6/tailwind.min.css" rel="stylesheet">
         <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
         <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
         <style>.toastify-center { max-width: calc(100% - 30px); }</style>

--- a/src/Vendr.DemoStore.Web/Views/ProductPage.cshtml
+++ b/src/Vendr.DemoStore.Web/Views/ProductPage.cshtml
@@ -85,7 +85,7 @@
 
                     <span class="relative">
                         <input type="radio" class="form-radio absolute w-0 h-0" name="productReference" id="giftcard-@productReference" value="@productReference" @Html.Raw(selectedReference == productReference ? "checked=\"checked\"" : "") />
-                        <label class="bg-gray-300 hover:bg-gray-400 border-2 text-gray-800 font-semibold py-2 px-4 cursor-pointer" for="giftcard-@productReference">@(variant.CalculatePrice()?.Formatted())</label>
+                        <label class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-semibold py-2 px-4 cursor-pointer" for="giftcard-@productReference">@(variant.CalculatePrice()?.Formatted())</label>
                     </span>
                 }
             </div>

--- a/src/Vendr.DemoStore.Web/Views/ProductPage.cshtml
+++ b/src/Vendr.DemoStore.Web/Views/ProductPage.cshtml
@@ -78,13 +78,15 @@
         {
             var selectedReference = addedProductReference ?? product.Variants.FirstOrDefault()?.GetProductReference();
 
-            <div class="gift-cards flex justify-start space-x-2 space-y-2 -mx-2">
+            <div class="gift-cards flex justify-start space-x-2 mt-4">
                 @foreach (var variant in product.Variants)
                 {
                     var productReference = variant.GetProductReference();
 
-                    <input type="radio" class="form-radio" name="productReference" id="giftcard-@productReference" value="@productReference" @Html.Raw(selectedReference == productReference ? "checked=\"checked\"" : "") />
-                    <label class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-semibold py-2 px-4 border-2 cursor-pointer rounded" for="giftcard-@productReference">@(variant.CalculatePrice()?.Formatted())</label>
+                    <span class="relative">
+                        <input type="radio" class="form-radio absolute w-0 h-0" name="productReference" id="giftcard-@productReference" value="@productReference" @Html.Raw(selectedReference == productReference ? "checked=\"checked\"" : "") />
+                        <label class="bg-gray-300 hover:bg-gray-400 border-2 text-gray-800 font-semibold py-2 px-4  cursor-pointer rounded" for="giftcard-@productReference">@(variant.CalculatePrice()?.Formatted())</label>
+                    </span>
                 }
             </div>
         }

--- a/src/Vendr.DemoStore.Web/Views/ProductPage.cshtml
+++ b/src/Vendr.DemoStore.Web/Views/ProductPage.cshtml
@@ -85,7 +85,7 @@
 
                     <span class="relative">
                         <input type="radio" class="form-radio absolute w-0 h-0" name="productReference" id="giftcard-@productReference" value="@productReference" @Html.Raw(selectedReference == productReference ? "checked=\"checked\"" : "") />
-                        <label class="bg-gray-300 hover:bg-gray-400 border-2 text-gray-800 font-semibold py-2 px-4  cursor-pointer rounded" for="giftcard-@productReference">@(variant.CalculatePrice()?.Formatted())</label>
+                        <label class="bg-gray-300 hover:bg-gray-400 border-2 text-gray-800 font-semibold py-2 px-4 cursor-pointer" for="giftcard-@productReference">@(variant.CalculatePrice()?.Formatted())</label>
                     </span>
                 }
             </div>

--- a/src/Vendr.DemoStore.Web/Views/ProductPage.cshtml
+++ b/src/Vendr.DemoStore.Web/Views/ProductPage.cshtml
@@ -78,12 +78,12 @@
         {
             var selectedReference = addedProductReference ?? product.Variants.FirstOrDefault()?.GetProductReference();
 
-            <div class="flex justify-start space-x-2 space-y-2 -mx-2">
+            <div class="gift-cards flex justify-start space-x-2 space-y-2 -mx-2">
                 @foreach (var variant in product.Variants)
                 {
                     var productReference = variant.GetProductReference();
 
-                    <input type="radio" class="hidden form-radio" name="productReference" id="giftcard-@productReference" value="@productReference" @Html.Raw(selectedReference == productReference ? "checked=\"checked\"" : "") />
+                    <input type="radio" class="form-radio" name="productReference" id="giftcard-@productReference" value="@productReference" @Html.Raw(selectedReference == productReference ? "checked=\"checked\"" : "") />
                     <label class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-semibold py-2 px-4 border-2 cursor-pointer rounded" for="giftcard-@productReference">@(variant.CalculatePrice()?.Formatted())</label>
                 }
             </div>

--- a/src/Vendr.DemoStore.Web/Views/ProductPage.cshtml
+++ b/src/Vendr.DemoStore.Web/Views/ProductPage.cshtml
@@ -49,21 +49,7 @@
             {
                 <div class="py-10">
                     <h1 class="text-2xl font-bold">@Model.Parent.Name - @Model.Name</h1>
-                    @if (Model.Variants.Any())
-                    {
-                        <select name="productReference" class="w-full border border-gray-300 p-2 mt-1">
-                            @foreach (var variant in Model.Variants)
-                            {
-                                <option value="@variant.GetProductReference()" @Html.Raw(addedProductReference == variant.GetProductReference() ? "selected=\"selected\"" : "")>@(variant.Name) - @(variant.CalculatePrice()?.Formatted())</option>
-                            }
-                        </select>
-                    }
-                    else
-                    {
-                        @Html.Hidden("productReference", Model.GetProductReference())
-
-                        <p>@(Model.CalculatePrice()?.Formatted())</p>
-                    }
+                    @RenderVariants(Model, addedProductReference)
                 </div>
 
                 <button class="font-bold border-4 border-gray-900 px-6 py-3 mb-4 lg:w-1/2 hover:bg-teal-400 hover:border-teal-400 hover:text-white" type="submit">Add to Cart</button>
@@ -83,3 +69,41 @@
         </div>
     </div>
 </div>
+
+@helper RenderVariants(ProductPage product, string addedProductReference)
+{
+    if (product.Variants.Any())
+    {
+        if (product.IsGiftCard)
+        {
+            var selectedReference = addedProductReference ?? product.Variants.FirstOrDefault()?.GetProductReference();
+
+            <div class="flex justify-start space-x-2 space-y-2 -mx-2">
+                @foreach (var variant in product.Variants)
+                {
+                    var productReference = variant.GetProductReference();
+
+                    <input type="radio" class="hidden form-radio" name="productReference" id="giftcard-@productReference" value="@productReference" @Html.Raw(selectedReference == productReference ? "checked=\"checked\"" : "") />
+                    <label class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-semibold py-2 px-4 border-2 cursor-pointer rounded" for="giftcard-@productReference">@(variant.CalculatePrice()?.Formatted())</label>
+                }
+            </div>
+        }
+        else
+        {
+            <select name="productReference" class="w-full border border-gray-300 p-2 mt-1">
+                @foreach (var variant in product.Variants)
+                {
+                    var productReference = variant.GetProductReference();
+
+                    <option value="@productReference" @Html.Raw(addedProductReference == productReference ? "selected=\"selected\"" : "")>@(variant.Name) - @(variant.CalculatePrice()?.Formatted())</option>
+                }
+            </select>
+        }
+    }
+    else
+    {
+        @Html.Hidden("productReference", product.GetProductReference())
+
+        <p>@(product.CalculatePrice()?.Formatted())</p>
+    }
+}

--- a/src/Vendr.DemoStore.Web/css/main.css
+++ b/src/Vendr.DemoStore.Web/css/main.css
@@ -10,7 +10,6 @@
 /* Product Page */
 .gift-cards input[type="radio"]:checked + label {
     background-color: #81e6d9;
-    border-color: #4fd1c5;
 }
 
 /* Cart Table Styles */

--- a/src/Vendr.DemoStore.Web/css/main.css
+++ b/src/Vendr.DemoStore.Web/css/main.css
@@ -8,12 +8,8 @@
 }
 
 /* Product Page */
-.gift-cards input:checked + label {
-    border: 2px solid #757575;
-}
-.gift-cards .form-radio {
-    width: 0;
-    height: 0;
+.gift-cards input[type="radio"]:checked + label {
+    border-color: #757575;
 }
 
 /* Cart Table Styles */

--- a/src/Vendr.DemoStore.Web/css/main.css
+++ b/src/Vendr.DemoStore.Web/css/main.css
@@ -9,7 +9,8 @@
 
 /* Product Page */
 .gift-cards input[type="radio"]:checked + label {
-    border-color: #757575;
+    background-color: #81e6d9;
+    border-color: #4fd1c5;
 }
 
 /* Cart Table Styles */

--- a/src/Vendr.DemoStore.Web/css/main.css
+++ b/src/Vendr.DemoStore.Web/css/main.css
@@ -8,8 +8,12 @@
 }
 
 /* Product Page */
-input:checked + label {
+.gift-cards input:checked + label {
     border: 2px solid #757575;
+}
+.gift-cards .form-radio {
+    width: 0;
+    height: 0;
 }
 
 /* Cart Table Styles */

--- a/src/Vendr.DemoStore.Web/css/main.css
+++ b/src/Vendr.DemoStore.Web/css/main.css
@@ -7,6 +7,11 @@
     color: #1a1a1a;
 }
 
+/* Product Page */
+input:checked + label {
+    border: 2px solid #757575;
+}
+
 /* Cart Table Styles */
 .data-label-visible:before {
     content: attr(data-label);


### PR DESCRIPTION
It would be nice to demo that Vendr can handle multiple gift card amounts either as separate products or variants.

In this PR I have enhanced the Gift Card products with variant nodes and used radio buttons and styled the labels a bit similar to the examples mentioned in this issue https://github.com/vendrhub/vendr-demo-store/issues/8

![image](https://user-images.githubusercontent.com/2919859/86034285-96da9b80-ba3a-11ea-8cc0-00ce78437d5c.png)

I have added the following Gift Card variants under the existing Gift Card product.

![image](https://user-images.githubusercontent.com/2919859/86034362-bd003b80-ba3a-11ea-9be1-0b75ca7cd075.png)