### PR TITLE
Fix indexing value of searchPath in Examine

### DIFF
--- a/src/Vendr.DemoStore/Composing/DemoStoreComponent.cs
+++ b/src/Vendr.DemoStore/Composing/DemoStoreComponent.cs
@@ -81,7 +81,7 @@ namespace Vendr.DemoStore.Composing
                     // Create searchable path
                     if (e.ValueSet.Values.ContainsKey("path"))
                     {
-                        e.ValueSet.Add("searchPath", e.ValueSet.Values["path"].ToString().Replace(',', ' '));
+                        e.ValueSet.Add("searchPath", e.ValueSet.GetValue("path").ToString().Replace(',', ' '));
                     }
 
                     // Stuff all the fields into a single field for easier searching


### PR DESCRIPTION
Fixes indexing value in `searchPath` field to be a path separated with spaces instead of returning a collection because `e.ValueSet.Values["path"]` returns `List<object>` which is the same has `e.ValueSet.GetValues("path")`

There is also a `.GetValue()` method which returns an object. Seems to do the same as `e.ValueSet.Values["path"][0]`.