### PR TITLE
Fix paging issue

### DIFF
--- a/src/Vendr.DemoStore/Web/ViewComponents/ProductViewComponentBase.cs
+++ b/src/Vendr.DemoStore/Web/ViewComponents/ProductViewComponentBase.cs
@@ -39,7 +39,7 @@ namespace Vendr.DemoStore.Web.ViewComponents
                 var searcher = index.Searcher;
                 var query = searcher.CreateQuery().NativeQuery(q);
                 var results = query.OrderBy(new SortableField("name", SortType.String))
-                    .Execute(QueryOptions.SkipTake(pageSize * (page - 1), pageSize * page));
+                    .Execute(QueryOptions.SkipTake(pageSize * (page - 1), pageSize));
                 var totalResults = results.TotalItemCount;
 
                 using (var ctx = _umbracoContextFactory.EnsureUmbracoContext())


### PR DESCRIPTION
Currently it multiply with `page` in the take part of `SkipTake()` which mean with a page size of 10 it skip 0 and take 10 (page 1), then skip 10 and take 20 (page 2), then skip 20 and take 30 (page 3), etc.

It should only take same number of items for each page.